### PR TITLE
travis-ci でPHP5.3と実行できるよう修正

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 
-sudo: false
+sudo: required
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ php:
   - 5.6
   - 5.5
   - 5.4
-  - 5.3
 
 env:
   # plugin code
@@ -32,6 +31,9 @@ env:
 
 matrix:
   fast_finish: true
+  include:
+    - php: 5.3
+      dist: precise
   exclude:
     - php: 7.1
       env: ECCUBE_VERSION=master DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres COVERRAGE=true

--- a/Controller/ConfigController.php
+++ b/Controller/ConfigController.php
@@ -47,5 +47,6 @@ class ConfigController extends AbstractController
                 'form' => $form->createView(),
             )
         );
+
     }
 }

--- a/Controller/ConfigController.php
+++ b/Controller/ConfigController.php
@@ -47,6 +47,5 @@ class ConfigController extends AbstractController
                 'form' => $form->createView(),
             )
         );
-
     }
 }


### PR DESCRIPTION
##概要(Overview・Refs Issue)
travisの問題に関しては、下記のようなことを修正します。
・「3.0.9」と「3.0.10」バージョンを削除する
・PHP5.3に対応します。下記のソースを追加します。
    include:
     - php: 5.3
       dist: precise
・travisの環境：「sudo: false」を「sudo: required」に変更します。
※理由は
・Trustyステータスで、TravisがPHP5.3にサポートしないからです。（https://blog.travis-ci.com/2017-08-31-trusty-as-default-status）
・「sudo: false」を「sudo: required」に変更することに関しては、https://github.com/travis-ci/travis-ci/issues/6861参照お願いいたします